### PR TITLE
RIS export was missing the ER (End Record) field to separate documents

### DIFF
--- a/index.js
+++ b/index.js
@@ -218,6 +218,7 @@ function _pusher(stream, isLast, child, settings) {
 		.flatten() // Transform back into a iterable array
 		.map(field => `${_fieldTranslationsReverse[field.key].ris}- ${field.value}`)
 		.join('\n');
+	buffer += '\nER  - \n';
 
 	stream.write(_.trimEnd(buffer) + (!isLast ? '\n' : ''));
 };


### PR DESCRIPTION
So EndNote/Mendelay only imports one document (with hundreds of authors and keywords).

I noticed it was present in the original PHP project, so I guess it got missed in the port to Node. 

Not sure if this is the best implementation.